### PR TITLE
made node scripts directly executable

### DIFF
--- a/node_server.js
+++ b/node_server.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Spacebrew Server
  * ----------------

--- a/node_server_forever.js
+++ b/node_server_forever.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * Spacebrew Server with Forever
  * ------------------------------


### PR DESCRIPTION
added shebang at top of node files and made them executable so you no longer need to call `node` when running them:
- old: `node node_server_forever.js`
- new: `./node_server_forever.js`

This is helpful for automation scripts which start the process in screen:
`screen -L -d -m -S spacebrew ./node_server_forever.js`
