### PR TITLE
fix disconnect detection bug

### DIFF
--- a/spacebrew.js
+++ b/spacebrew.js
@@ -282,6 +282,7 @@ spacebrew.createServer = function( opts ){
          * @param  {obj} ws The object containing information about the connection that is being closed
          */
         ws.on('close', function(ws) {
+            connection.wasClosed = true;
             cleanupClosedConnections();
         });
 
@@ -941,7 +942,7 @@ spacebrew.createServer = function( opts ){
 
         for(var i = 0; i < trustedClients.length;){
             //logger.log("info", trustedClients);
-            if (!trustedClients[i].connection._socket){
+            if (trustedClients[i].connection.wasClosed){
                 removeRoutesInvolvingClient(trustedClients[i]);
                 removed.push({name:trustedClients[i].name, remoteAddress:trustedClients[i].remoteAddress});
                 trustedClients.splice(i, 1);
@@ -953,7 +954,7 @@ spacebrew.createServer = function( opts ){
         //remove Admins
         //logger.log("info", "There are admins: "+ adminConnections.length);
         for(var i = 0; i < adminConnections.length;){
-            if (adminConnections[i]._socket == null){
+            if (adminConnections[i].wasClosed){
                 adminConnections.splice(i, 1);
             } else {
                 i++;
@@ -961,7 +962,7 @@ spacebrew.createServer = function( opts ){
         }
         //remove connections
         for(var i = 0; i<allconnections.length;){
-            if (allconnections[i]._socket == null){
+            if (allconnections[i].wasClosed){
                 allconnections.splice(i, 1);
             } else {
                 i++;

--- a/spacebrew.js
+++ b/spacebrew.js
@@ -282,7 +282,7 @@ spacebrew.createServer = function( opts ){
          * @param  {obj} ws The object containing information about the connection that is being closed
          */
         ws.on('close', function(ws) {
-            connection.wasClosed = true;
+            connection.spacebrew_was_closed = true;
             cleanupClosedConnections();
         });
 
@@ -942,7 +942,7 @@ spacebrew.createServer = function( opts ){
 
         for(var i = 0; i < trustedClients.length;){
             //logger.log("info", trustedClients);
-            if (trustedClients[i].connection.wasClosed){
+            if (trustedClients[i].connection.spacebrew_was_closed){
                 removeRoutesInvolvingClient(trustedClients[i]);
                 removed.push({name:trustedClients[i].name, remoteAddress:trustedClients[i].remoteAddress});
                 trustedClients.splice(i, 1);
@@ -954,7 +954,7 @@ spacebrew.createServer = function( opts ){
         //remove Admins
         //logger.log("info", "There are admins: "+ adminConnections.length);
         for(var i = 0; i < adminConnections.length;){
-            if (adminConnections[i].wasClosed){
+            if (adminConnections[i].spacebrew_was_closed){
                 adminConnections.splice(i, 1);
             } else {
                 i++;
@@ -962,7 +962,7 @@ spacebrew.createServer = function( opts ){
         }
         //remove connections
         for(var i = 0; i<allconnections.length;){
-            if (allconnections[i].wasClosed){
+            if (allconnections[i].spacebrew_was_closed){
                 allconnections.splice(i, 1);
             } else {
                 i++;


### PR DESCRIPTION
Hi,

I'm working on an installation where I need to be able to tell reliably when a client was disconnected. For this, I'm using [sb-admin](https://github.com/Spacebrew/spacebrew.js/blob/master/library/sb-admin-0.1.4.js). It looks like sometimes Spacebrew has issues with detecting correctly if (or when) a client disconnected.

I wrote a little [test app](https://gist.github.com/snorpey/05ba1b0e932fb0ef0d10) ([download here](https://gist.github.com/snorpey/05ba1b0e932fb0ef0d10/download)) to have a closer look at the behavior.

![screencapture-07](https://cloud.githubusercontent.com/assets/166433/6179002/ed6f9348-b314-11e4-9d37-e44a894ec016.gif)

In the video capture you see a normal client on the left side and an admin client on the right side. Ideally, they should always be in sync. As you can see often times the admin client on the right side is not notified if the client disconnects. 

I was able to fix this issue by setting a flag on the connection object when the socket is closed. In the ``cleanupClosedConnections`` I'm then checking if the flag was set instead of looking at the socket.

![screencapture-08](https://cloud.githubusercontent.com/assets/166433/6179074/cb982f5e-b315-11e4-9894-e63a3d535cd7.gif)

While this is fixing an issue I'm having, I'm not sure if my changes interfere with other use cases or if this behavior is actually intended.