### PR TITLE
fix issues starting from other working dirs by changing to script dir…

### DIFF
--- a/node_persistent_admin.js
+++ b/node_persistent_admin.js
@@ -1,3 +1,4 @@
+process.chdir(__dirname);
 var processArguments = function(){
     var argv = process.argv;
     for(var i = 2; i < argv.length; i++){


### PR DESCRIPTION
… in node_persistent_admin.js. This situation occurred in a recent project where I used https://github.com/tallesl/qckwinsvc to bundle my node scripts into windows services. This context broke node_persistent_admin's dependence on its local working directory. Changing to the scripts directory at the top fixes it, and preserves normal function in all other contexts I knew to test.